### PR TITLE
Add response help text

### DIFF
--- a/demos/PersonalizerBusinessDemo/PersonalizerBusinessDemo/Views/Home/Index.cshtml
+++ b/demos/PersonalizerBusinessDemo/PersonalizerBusinessDemo/Views/Home/Index.cshtml
@@ -217,12 +217,15 @@ In this demo, reward is computed by seeing how far down the user scrolls. This r
                     </div>
                 </div>
 
-                <div class="row pt-2 d-none" id="result-section">
+                <div class="row pt-2">
                     <div class="col-12">
                         <div class="card">
                             <div class="card-body p-0">
                                 <h5 class="card-title ml-2 mt-2">Response</h5>
-                                <pre class="pre-scrollable responseRequestContainers border mb-3 p-1 responsejson"><code id="result-code"></code></pre>
+                                <div class="alert alert-secondary m-2" role="alert" id="result-alert">
+                                    When you click the button, the Personalizer Rank will be called with the arguments above and outputs will be shown here.
+                                </div>
+                                <pre class="d-none pre-scrollable responseRequestContainers border mb-3 p-1 responsejson" id="result-container"><code id="result-code"></code></pre>
 
                                 <h6 class="card-subtitle ml-2 mt-2">For this Rank call, Personalizer was</h6>
                                 <div class="card-group p-3">

--- a/demos/PersonalizerBusinessDemo/PersonalizerBusinessDemo/wwwroot/js/demo.js
+++ b/demos/PersonalizerBusinessDemo/PersonalizerBusinessDemo/wwwroot/js/demo.js
@@ -326,14 +326,20 @@ function ramdomizeSelectedOption(select) {
 
 function updateBasedOnRecommendation(result) {
     showResultContainer();
+    hideResultAlert();
     updateArticle(result);
     updateResult(result);
     updatePersonalizerMethod(result);
 }
 
 function showResultContainer() {
-    const resultContainerEle = document.getElementById("result-section");
+    const resultContainerEle = document.getElementById("result-container");
     resultContainerEle.classList.remove("d-none");
+}
+
+function hideResultAlert() {
+    const resultAlertElement = document.getElementById("result-alert");
+    resultAlertElement.classList.add("d-none");
 }
 
 function updatePersonalizerMethod(recommendation) {


### PR DESCRIPTION
Added back the response help text. Now the whole response section works as in the old demo, showing the whole time. It starts with the help text and removes it after the first Personalizer call.

![image](https://user-images.githubusercontent.com/14252330/61640897-7de73900-ac74-11e9-82dc-b1e6da5488b2.png)
