### PR TITLE
Add chart animation when opening and center modal text

### DIFF
--- a/demos/PersonalizerBusinessDemo/PersonalizerBusinessDemo/Views/Home/Index.cshtml
+++ b/demos/PersonalizerBusinessDemo/PersonalizerBusinessDemo/Views/Home/Index.cshtml
@@ -310,10 +310,12 @@
     <div class="modal-dialog modal-xl modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h3 class="modal-title">Learning Simulator</h3>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
+                <h5 class="col-md-12 modal-title text-center" id="about-modal-title">
+                    Learning Simulator
+                    <button type="button" class="close pr-0" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </h5>
             </div>
             <div class="modal-body">
                 <div class="learn-container" id="graph-container">

--- a/demos/PersonalizerBusinessDemo/PersonalizerBusinessDemo/wwwroot/js/learn-charts.js
+++ b/demos/PersonalizerBusinessDemo/PersonalizerBusinessDemo/wwwroot/js/learn-charts.js
@@ -196,7 +196,10 @@
     let intervalId = -1;
 
     startLearnBtnEle.addEventListener("click", function () {
+        runAnimation();
+    });
 
+    function runAnimation() {
         if (intervalId >= 0) {
             clearInterval(intervalId);
         }
@@ -220,5 +223,9 @@
             currentTick++;
 
         }, 10);
+    }
+
+    document.getElementById("learnModal").addEventListener("transitionend", function () {
+        runAnimation();
     });
 });


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Run Chart animation when opening the modal.
* Center modal text (copy the style from the about modal).
![image](https://user-images.githubusercontent.com/42191764/61827226-6eb1e800-ae3a-11e9-9934-36a299b120f0.png)


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: UI
```
