### PR TITLE
Reset reward gauge when the Show Personalized Checkout is clicked

### DIFF
--- a/demos/PersonalizerTravelAgencyDemo/PersonalizerTravelAgencyDemo/wwwroot/js/demo.js
+++ b/demos/PersonalizerTravelAgencyDemo/PersonalizerTravelAgencyDemo/wwwroot/js/demo.js
@@ -81,6 +81,7 @@ document.addEventListener("DOMContentLoaded", function () {
     };
 
     goBtnEle.addEventListener("click", function () {
+        resetRewardGauge(gaugeInterval);
         getRecommendation().then(result => {
             personalizerCallResult = result;
             updateBasedOnRecommendation(result);
@@ -179,8 +180,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 iframeBackBtn.addEventListener("click", function () {
                     gaugeContainerEle.style.display = 'none';
                     articleViewer.contentWindow.history.back();
-                    clearInterval(gaugeInterval);
-                    gaugeInterval = -1;
+                    resetRewardGauge(gaugeInterval);
                 });
             }
 
@@ -198,6 +198,11 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     });
 });
+
+function resetRewardGauge(gaugeInterval){
+    clearInterval(gaugeInterval);
+    gaugeInterval = -1;
+}
 
 function updateRewardValue(value, articleDoc) {
     const turnValue = value/2;


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* I created a new function that resets the Reward Gauge. I placed it in the click listener of the Show Personalizer Checkout button and the Back button

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```