### PR TITLE
Fix checkout modal navigation

### DIFF
--- a/demos/PersonalizerTravelAgencyDemo/PersonalizerTravelAgencyDemo/Views/Home/Partials/_CheckoutModal.cshtml
+++ b/demos/PersonalizerTravelAgencyDemo/PersonalizerTravelAgencyDemo/Views/Home/Partials/_CheckoutModal.cshtml
@@ -1,12 +1,12 @@
 ﻿@model PersonalizerTravelAgencyDemo.Models.Action
 
-<div class="modal fade" id="checkout-modal" tabindex="-1" role="dialog" aria-labelledby="checkout-modal-title" aria-hidden="true">
+<div class="modal fade" id="checkout-modal" tabindex="-1" role="dialog" aria-labelledby="checkout-modal-title" data-backdrop="static" data-keyboard="false" aria-hidden="true">
     <div class="modal-dialog about-modal modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="col-md-12 modal-title text-center" id="about-modal-title">
                     This is the checkout page
-                    <button type="button" class="close pr-0" data-dismiss="modal" aria-label="Close">
+                    <button type="button" class="close pr-0" id="endModal-close-icon" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
                 </h5>
@@ -24,7 +24,7 @@
                 </p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                <button type="button" id="endModal-close-button" class="btn btn-secondary" data-dismiss="modal">Try Again</button>
             </div>
         </div>
     </div>

--- a/demos/PersonalizerTravelAgencyDemo/PersonalizerTravelAgencyDemo/wwwroot/js/demo.js
+++ b/demos/PersonalizerTravelAgencyDemo/PersonalizerTravelAgencyDemo/wwwroot/js/demo.js
@@ -147,9 +147,24 @@ document.addEventListener("DOMContentLoaded", function () {
     articleViewer.addEventListener("load", function () {
         const articleDoc = articleViewer.contentDocument;
         const mainContainer = articleViewer.contentWindow.document.getElementById("main-container");
-        const articleFooter = articleViewer.contentWindow.document.getElementById("article-footer");
         const gauge = articleViewer.contentWindow.document.getElementById("gauge");
         const boundSetIframeContentSize = setIframeContentSize.bind(null, mainContainer);
+        const modalButton = articleViewer.contentWindow.document.getElementById('endModal-close-button');
+        const modalIcon = articleViewer.contentWindow.document.getElementById('endModal-close-icon');
+        const checkoutModal = articleViewer.contentWindow.document.getElementById('modal-checkout');
+
+        modalButton.addEventListener('click', function () {
+            goToHomeSite();
+        })
+
+        modalIcon.addEventListener('click', function () {
+            goToHomeSite();
+        })
+
+        checkoutModal.addEventListener('blur', function () {
+            goToHomeSite();
+        })
+
 
         getRecommendation().then(result => {
             personalizerCallResult = result;
@@ -198,7 +213,7 @@ document.addEventListener("DOMContentLoaded", function () {
                     }
 
                 }, RewardDecreaseInterval * 1000);
-            }, false);            
+            }, false);
 
             var innerDoc = articleViewer.contentWindow.document;
             var iframeBackBtn = innerDoc.getElementById('iframe-backBtn');
@@ -506,4 +521,9 @@ function updateRecommendation() {
         personalizerCallResult = result;
         updateBasedOnRecommendation(result);
     });
+}
+
+function goToHomeSite() {
+    const articleViewer = document.getElementById("article-viewer");
+    articleViewer.src = '/home/HomeSite';
 }

--- a/demos/PersonalizerTravelAgencyDemo/PersonalizerTravelAgencyDemo/wwwroot/js/demo.js
+++ b/demos/PersonalizerTravelAgencyDemo/PersonalizerTravelAgencyDemo/wwwroot/js/demo.js
@@ -152,10 +152,6 @@ document.addEventListener("DOMContentLoaded", function () {
         const modalButton = articleViewer.contentWindow.document.getElementById('endModal-close-button');
         const modalIcon = articleViewer.contentWindow.document.getElementById('endModal-close-icon');
 
-        modalButton.addEventListener('click', goToHomeSite);
-
-        modalIcon.addEventListener('click', goToHomeSite);
-
         getRecommendation().then(result => {
             personalizerCallResult = result;
         });
@@ -185,6 +181,10 @@ document.addEventListener("DOMContentLoaded", function () {
                 sendRewardHandler(SaveForLaterReward);
                 updateRewardValue(SaveForLaterReward, articleDoc);
             });
+
+            modalButton.addEventListener('click', goToHomeSite);
+
+            modalIcon.addEventListener('click', goToHomeSite);
 
             updateShowGraphbtn(true);
 

--- a/demos/PersonalizerTravelAgencyDemo/PersonalizerTravelAgencyDemo/wwwroot/js/demo.js
+++ b/demos/PersonalizerTravelAgencyDemo/PersonalizerTravelAgencyDemo/wwwroot/js/demo.js
@@ -151,15 +151,10 @@ document.addEventListener("DOMContentLoaded", function () {
         const boundSetIframeContentSize = setIframeContentSize.bind(null, mainContainer);
         const modalButton = articleViewer.contentWindow.document.getElementById('endModal-close-button');
         const modalIcon = articleViewer.contentWindow.document.getElementById('endModal-close-icon');
-        const checkoutModal = articleViewer.contentWindow.document.getElementById('modal-checkout');
 
-        modalButton.addEventListener('click', function () {
-            goToHomeSite();
-        })
+        modalButton.addEventListener('click', goToHomeSite);
 
-        modalIcon.addEventListener('click', function () {
-            goToHomeSite();
-        })
+        modalIcon.addEventListener('click', goToHomeSite);
 
         getRecommendation().then(result => {
             personalizerCallResult = result;

--- a/demos/PersonalizerTravelAgencyDemo/PersonalizerTravelAgencyDemo/wwwroot/js/demo.js
+++ b/demos/PersonalizerTravelAgencyDemo/PersonalizerTravelAgencyDemo/wwwroot/js/demo.js
@@ -161,11 +161,6 @@ document.addEventListener("DOMContentLoaded", function () {
             goToHomeSite();
         })
 
-        checkoutModal.addEventListener('blur', function () {
-            goToHomeSite();
-        })
-
-
         getRecommendation().then(result => {
             personalizerCallResult = result;
         });


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
*When closing the checkout modal from the confirmation page, the modal now navigates back to the HomeSite, also, the option to click outside of the modal to exit was removed, as it's the final page. 

*Changed the close button text to "Try Again"

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```